### PR TITLE
Add error handler that redirects to /error

### DIFF
--- a/lib/controllers/saml-verify.js
+++ b/lib/controllers/saml-verify.js
@@ -2,7 +2,6 @@
 
 var url = require('url');
 var stormpath = require('stormpath');
-
 var helpers = require('../helpers');
 
 /**
@@ -30,7 +29,7 @@ module.exports = function (req, res) {
   assertionAuthenticator.authenticate(stormpathToken, function (err) {
     if (err) {
       logger.info('During a SAML login attempt, we were unable to verify the JWT response.');
-      return helpers.writeJsonError(res, err);
+      return helpers.errorRedirect(res, err);
     }
 
     function redirectNext() {
@@ -45,19 +44,19 @@ module.exports = function (req, res) {
       stormpathTokenAuthenticator.authenticate({ stormpath_token: stormpathToken }, function (err, authenticationResult) {
         if (err) {
           logger.info('During a SAML login attempt, we were unable to create a Stormpath session.');
-          return helpers.writeJsonError(res, err);
+          return helpers.errorRedirect(res, err);
         }
 
         authenticationResult.getAccount(function (err, account) {
           if (err) {
             logger.info('During a SAML login attempt, we were unable to retrieve an account from the authentication result.');
-            return helpers.writeJsonError(res, err);
+            return helpers.errorRedirect(res, err);
           }
 
           helpers.expandAccount(account, config.expand, logger, function (err, expandedAccount) {
             if (err) {
               logger.info('During a SAML login attempt, we were unable to expand the Stormpath account.');
-              return helpers.writeJsonError(res, err);
+              return helpers.errorRedirect(res, err);
             }
 
             helpers.createSession(authenticationResult, expandedAccount, req, res);

--- a/lib/helpers/error-redirect.js
+++ b/lib/helpers/error-redirect.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Use this method to render JSON error responses.
+ *
+ * @function
+ *
+ * @param {Object} res - Express http response.
+ * @param {Object} err - An error object.
+ */
+function errorRedirect(res, err) {
+  var message = 'Unknown error. Please contact support.';
+
+  if (err) {
+    message = err.userMessage || err.message;
+  }
+
+  res.redirect('/error?msg=' + message);
+}
+
+module.exports = errorRedirect;

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -24,5 +24,6 @@ module.exports = {
   xsrfValidator: require('./xsrf-validator'),
   revokeToken: require('./revoke-token'),
   getFormViewModel: require('./get-form-view-model').default,
-  strippedAccountResponse: require('./stripped-account-response')
+  strippedAccountResponse: require('./stripped-account-response'),
+  errorRedirect: require('./error-redirect')
 };


### PR DESCRIPTION
Instead of dumping JSON errors to the page, this will redirect to a `/error?msg=Some error message` which the frontend will handle and display nicely.